### PR TITLE
 When user clicks the browser's stop sharing button, stop the recording.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,9 @@ export function useReactMediaRecorder({
         const stream = (await window.navigator.mediaDevices.getDisplayMedia({
           video: video || true,
         })) as MediaStream;
+        stream.getVideoTracks()[0].addEventListener("ended", () => {
+          stopRecording();
+        });
         if (audio) {
           const audioStream = await window.navigator.mediaDevices.getUserMedia({
             audio,


### PR DESCRIPTION
When recording the screen, if the user clicks the `stop sharing` button the recorder should stop recording. 
This doesn't happen, recording goes on. The user has to navigate to the app UI and click the `stop recording` button in the browser to stop recording.
![browser-stop-sharing-button](https://user-images.githubusercontent.com/5907294/138471469-4b26a44f-076f-4aea-a3c6-594297a0de61.PNG)

The 'ended' event is fired when the `stop sharing` button is clicked. 
The proposed change listens for this event and calls `stopRecording`.